### PR TITLE
support absolute http and https urls in header menu items

### DIFF
--- a/base/header.htm
+++ b/base/header.htm
@@ -41,6 +41,10 @@ if($hasMenuItems) {
   print '<div id="header">';
   for($i=0; $i<$menuLinkCount; $i++) {
     print '<a href="';
+    if (! (substr($menuLinks[$i]['MenuLinkURL'], 0, 7) == 'http://' ||
+           substr($menuLinks[$i]['MenuLinkURL'], 0, 8) == 'https://') ) {
+      printRoot();
+    }
     printRoot();
     //print '/';
     print $menuLinks[$i]['MenuLinkURL'];


### PR DESCRIPTION
We want to be able to use absolute URLs in the header's menu items.  The current code just appends them to the base/root URL, but we should override that behavior for non-relative URLs.

This is a quick fix; it would be better to use something like `parse_url()`, but this works for our purposes and I didn't have the time to go look up the docs for `parse_url` and do proper error checking/handling.