### PR TITLE
Support schedule days that consume two "Session" entries

### DIFF
--- a/base/config.yaml
+++ b/base/config.yaml
@@ -20,7 +20,12 @@ MenuLinks:
 FirstQuarterDay: 2016-03-07
 LastBeforeBreak: 2016-04-01
 FirstAfterBreak: 2016-04-11
-ClassOnWeekDays: mtrf
+############################################################
+#VERY IMPORTANT NOTE:
+# Uppercase chars in ClassOnWeekDays consumes two "Session:" blocks 
+# in the content.md schedule source.
+ClassOnWeekDays: mtWrf
+############################################################
 ShowPastSessions: 0
 ShowFutureSessions: 5
 

--- a/base/content.md
+++ b/base/content.md
@@ -15,6 +15,7 @@ Session:
 * Bullet lists might be useful
  * +Plus symbols automatically link to that resource
  * Due dates are counted in sessions units due +4
+ * Due Items / can be annotated without changing the link due +5
  //* Items can be commented
  * Links can be <a href="resource">manually</a> added due +3
 

--- a/htmlSchedule.php
+++ b/htmlSchedule.php
@@ -198,11 +198,16 @@ function getBulletList($string, $currentDay, &$itemsDue)
 
 				$endOfDay = new DateInterval('PT23H59M');
 				$dueDate = $currentDay;
-				for($d=0; $d<$daysTillDue; $d++) {
+				for($d=$daysTillDue; $d>0; $d--) {
 					// skip two sessions for double-session days
-					if (isDoubleDay($dueDate)) { $d++; }
+					if (isDoubleDay($dueDate)) { $d--; }
 					$dueDate = getNextClassDay($dueDate);
 				}
+
+				// // can use this for debugging:
+				// $logger = '<script language="javascript">'
+				//	 . 'console.log(\'' . $session . ' due ' . $daysTillDue . '\');</script>';
+				// $session = $session . $logger;
 
 				$session = $session . ' ' . $session_annotation . ' (due ' .$dueDate->format('D M d') .')';
 				//TODO fix timezone issue
@@ -221,8 +226,11 @@ function getBulletList($string, $currentDay, &$itemsDue)
 
 	foreach($itemsDue as $item)
 	{
-		if($item->daysTillDue == 0)
+		// This loop iterates through items and collects any items due.
+		if(($item->daysTillDue == 0) or
+		   ($item->daysTillDue == 1 and isDoubleDay($currentDay))) {
 			$list = $list . '* Due: '.$item->session."\n";
+		}
 	}
 
 	return $list;

--- a/htmlSchedule.php
+++ b/htmlSchedule.php
@@ -169,7 +169,18 @@ function getBulletList($string, $currentDay, &$itemsDue)
 			{
 				$p = explode('due +', $session);
 				$session = $p[0];
+				$session_annotation = "";
+
+				// if item contains a '/' char, everything after the '/' is not part of the link.
+				if (strpos($session, '/'))
+				{
+					$q = explode('/', $p[0]);
+					$session = $q[0];
+					$session_annotation = $q[1];
+				}
+
 				$session = getItemLink($session);
+
 				$daysTillDue = $p[1];
 
 				$itemDue = new ItemDue();
@@ -179,9 +190,11 @@ function getBulletList($string, $currentDay, &$itemsDue)
 
 				$endOfDay = new DateInterval('PT23H59M');
 				$dueDate = $currentDay;
-				for($d=0; $d<$daysTillDue; $d++)
+				for($d=0; $d<$daysTillDue; $d++) {
 					$dueDate = getNextClassDay($dueDate);
-				$session = $session . ' (due ' .$dueDate->format('D M d') .')';
+				}
+
+				$session = $session . ' ' . $session_annotation . ' (due ' .$dueDate->format('D M d') .')';
 				//TODO fix timezone issue
 				$dueDate->add($endOfDay);
 				//$timer = '<script language="javascript">timer('. $dueDate->format('U') .');</script>';


### PR DESCRIPTION
Sometimes classes meet on multiple days where some of the days have longer sessions than others; for example, I have a class that meets four days a week for an hour and once more that week for two hours.    It meets mtrf for an hour and W for two hours, so it looks like this: `mtWrf` (uppercased W session is "double"-length).

For agility, we'd like to offer the same class with three two-hour blocks, effectively combining the `mt` and `rf` blocks into one: `MWF`.

If we could identify which days are "double" blocks, we could easily use the same content.md file to fit either meeting schedule without any changes.  Each `Session:` block would be 1h, and we could automatically combine two sessions into one for uppercase letters leaving the lower case ones at "single length".

This code makes that change; now in the yaml file, any uppercase letters consume two session blocks, and I've attempted to update due dates accordingly.