### PR TITLE
Support both absolute URLs and line comments

### DIFF
--- a/htmlSchedule.php
+++ b/htmlSchedule.php
@@ -74,7 +74,7 @@ function removeCommentLines($string)
 
 	foreach($lines as $line)
 	{
-		$commented = 1 == preg_match('_\s*//.*_', $line);
+		$commented = 1 == preg_match('_(\s+|^)//.*_', $line);
 		if( !$commented )
 			$outS = $outS . $line . "\n";
 	}


### PR DESCRIPTION
See https://github.com/KixorTech/CourseUp/issues/8

Absolute URLs `https://foo.bar/baz` in md files are considered line comments, which strips off most of the business end of the URL.  To support both absolute URLs and line comments, the regular expression that finds line comments should require either of these two cases:
1. The line comment begins at the first character of the line
2. The line comment has at least one whitespace char preceding it

If either of those is true, it's probably not a URL (since URLs usually have :// first).  Alternatively, we could require the char before // *not* be a colon, but that might be a little too strange.