### PR TITLE
add styling to show which menu link is active

### DIFF
--- a/base/header.htm
+++ b/base/header.htm
@@ -40,15 +40,21 @@ $hasMenuItems = $menuLinkCount > 0 || $online;
 if($hasMenuItems) {
   print '<div id="header">';
   for($i=0; $i<$menuLinkCount; $i++) {
+    $cur_menu_url = $menuLinks[$i]['MenuLinkURL'];
     print '<a href="';
     if (! (substr($menuLinks[$i]['MenuLinkURL'], 0, 7) == 'http://' ||
            substr($menuLinks[$i]['MenuLinkURL'], 0, 8) == 'https://') ) {
       printRoot();
+      $cur_menu_url = getWebRoot() . $cur_menu_url;
     }
-    printRoot();
+
     //print '/';
     print $menuLinks[$i]['MenuLinkURL'];
-    print '">';
+    print '"';
+
+    if($cur_menu_url == getUri()) { print ' class="currentPage"'; }
+
+    print '>';
     print $menuLinks[$i]['MenuLinkName'];
     print '</a>';
     print "\n";

--- a/base/include/screen.css
+++ b/base/include/screen.css
@@ -138,6 +138,10 @@ background: #555;
 background: #222;
 }
 
+#header .currentPage{
+background: #777;
+}
+
 .noBullets {
 list-style-type: none;
 }


### PR DESCRIPTION
It would be nice if the links at the top of the page indicated which link is currently active. 

I'm thinking making the background of the link a shade lighter if it is a link to the currently loaded document would be a nice hint to a site viewer that this is the current page.

This screenshot shows what it looks like when the "Schedule" (main) page is active on this instance:
<img width="400" height="150" alt="image" src="https://github.com/user-attachments/assets/775b3526-1edd-4ca6-bf4b-2cd2c2216cc3" />

@kixornet - whatcha think?